### PR TITLE
Enhancement : Handle JsonDataException

### DIFF
--- a/common/src/main/java/sample/ritwik/common/mvvm/viewModel/BaseViewModel.kt
+++ b/common/src/main/java/sample/ritwik/common/mvvm/viewModel/BaseViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
+import com.squareup.moshi.JsonDataException
+
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.*
@@ -178,6 +180,7 @@ abstract class BaseViewModel<Repository : BaseRepository, Model : BaseModel> : V
         is SSLHandshakeException -> ResultWrapper.Error.SSLHandShakeError()
         is IOException -> ResultWrapper.Error.NetworkError()
         is HttpException -> handleHTTPException(throwable, errorResponseClass, handleErrorCode)
+        is JsonDataException -> ResultWrapper.Error.RecoverableError(401, throwable.message ?: repository.getStringFromResource(R.string.default_json_error_message))
         else -> ResultWrapper.Error.Other()
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="default_error_message">Something went wrong. Please try again later.</string>
     <string name="default_failure_message">We are unable to load content. Please check connectivity and retry. If the problem persists, try after sometime.</string>
     <string name="default_ssl_error_message">It seems some issue with SSL Handshake.\nPlease inform the Administrator.</string>
+    <string name="default_json_error_message">There seems to be a mismatch between the Data Received as JSON and the Response Data Class.</string>
 
     <!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Content Descriptions ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
 


### PR DESCRIPTION
Added code to handle `JsonDataException` caused by `Moshi`.

This in turn affected `BaseViewModel.kt` as below:
```kotlin
/**
  * Handles the different types of Exceptions that may have caused during
  * performing REST API Call.
  *
  * @param TypeREST Any Class which holds the response of REST API Call.
  * @param TypeErrorResponse Any Class which extends [BaseErrorResponse], acts as the
  *   Error Response Body.
  * @param throwable Instance of [Throwable] denoting the Exception Super-Class which contains
  *   more details about the error cause.
  * @param errorResponseClass [Class] of [TypeErrorResponse].
  * @param handleErrorCode Lambda Expression that processes the Error Code before
  *   executing 'handleError'.
  */
private fun <TypeREST, TypeErrorResponse : BaseErrorResponse> handleException(
    throwable: Throwable,
    errorResponseClass: Class<TypeErrorResponse>,
    handleErrorCode: (Int, TypeErrorResponse) -> ResultWrapper.Error<TypeREST>
): ResultWrapper.Error<TypeREST> = when (throwable) {
    is ConnectException -> ResultWrapper.Error.NetworkConnectionError()
    is SSLHandshakeException -> ResultWrapper.Error.SSLHandShakeError()
    is IOException -> ResultWrapper.Error.NetworkError()
    is HttpException -> handleHTTPException(throwable, errorResponseClass, handleErrorCode)
    is JsonDataException -> ResultWrapper.Error.RecoverableError(401, throwable.message ?: repository.getStringFromResource(R.string.default_json_error_message))
    else -> ResultWrapper.Error.Other()
}
```

Now, `JsonDataException` will be reported as a Recoverable Error, in which the cause of JSON Exception is mentioned.

Also added a String Resource in `strings.xml`, denoting the default message of JSON Exception when the throwable does not have the message.

```xml
<string name="default_json_error_message">There seems to be a mismatch between the Data Received as JSON and the Response Data Class.</string>
```