### PR TITLE
FIX: Shimmer

### DIFF
--- a/app/src/main/java/sample/ritwik/app/ui/fragment/CommonFragment.kt
+++ b/app/src/main/java/sample/ritwik/app/ui/fragment/CommonFragment.kt
@@ -52,11 +52,11 @@ class CommonFragment : BaseFragment<FragmentCommonBinding, MainModel, MainViewMo
 
     override fun showLoading() = binding?.placeholderShimmerContainer?.let { shimmer ->
         shimmer.visibility = View.VISIBLE
-        shimmer.startShimmerAnimation()
+        shimmer.startShimmer()
     } ?: Unit
 
     override fun hideLoading() = binding?.placeholderShimmerContainer?.let { shimmer ->
-        shimmer.stopShimmerAnimation()
+        shimmer.stopShimmer()
         shimmer.visibility = View.GONE
     } ?: Unit
 

--- a/app/src/main/res/layout/fragment_common.xml
+++ b/app/src/main/res/layout/fragment_common.xml
@@ -61,7 +61,7 @@
             app:layout_constraintTop_toBottomOf="@id/placeholder_text_title"
             tools:listitem="@layout/item_library_component" />
 
-        <io.supercharge.shimmerlayout.ShimmerLayout
+        <com.facebook.shimmer.ShimmerFrameLayout
             android:id="@+id/placeholder_shimmer_container"
             android:layout_width="0dp"
             android:layout_height="0dp"
@@ -109,7 +109,7 @@
 
             </LinearLayout>
 
-        </io.supercharge.shimmerlayout.ShimmerLayout>
+        </com.facebook.shimmer.ShimmerFrameLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     api 'io.supercharge:shimmerlayout:2.1.0'
     api 'com.google.code.gson:gson:2.8.6'
     api 'androidx.datastore:datastore-preferences:1.0.0-alpha04'
-    api 'io.supercharge:shimmerlayout:2.1.0'
+    api 'com.facebook.shimmer:shimmer:0.5.0'
     kapt 'com.google.dagger:dagger-android-processor:2.15'
     kapt 'com.google.dagger:dagger-compiler:2.15'
     kapt 'androidx.databinding:databinding-compiler:4.1.1'


### PR DESCRIPTION
Tried [`ShimmerLayout`](https://github.com/team-supercharge/ShimmerLayout) by [Team Supercharge](https://github.com/team-supercharge) with every variation where there was no reference of `ShimmerLayout` was used.

But, the problem of Memory Leak persisted, and thus decided to remove [`ShimmerLayout`](https://github.com/team-supercharge/ShimmerLayout) by [Team Supercharge](https://github.com/team-supercharge) as the Library Dependency of `common` and replaced it with [Shimmer for Android](https://github.com/facebook/shimmer-android) by [Facebook](https://github.com/facebook/).

Also, to demonstrate the working of `ShimmerFrameLayout`, also refactored [`CommonFragment.kt`](https://github.com/ritwikjamuar/Common/blob/443957058e446dbc77dbaf20d2aef983f0f48c4d/app/src/main/java/sample/ritwik/app/ui/fragment/CommonFragment.kt) and it's associated layout [`fragment_common.xml`](https://github.com/ritwikjamuar/Common/blob/443957058e446dbc77dbaf20d2aef983f0f48c4d/app/src/main/res/layout/fragment_common.xml).